### PR TITLE
Fix 2 object rotations

### DIFF
--- a/object_rotations.lua
+++ b/object_rotations.lua
@@ -24,9 +24,9 @@ rotations.facedir = {
 	vector.new( 0, -r, -r),
 
 	vector.new( 0,  0,  r),
-	vector.new( 0, -r,  r),
-	vector.new( 0,  d,  r),
 	vector.new( 0,  r,  r),
+	vector.new( 0,  d,  r),
+	vector.new( 0,  -r,  r),
 
 	vector.new( 0,  0,  d),
 	vector.new( 0,  r,  d),


### PR DESCRIPTION
I did end up using your paste preview object rotations in a new version of edit. I also used the hollowing algorithm.
Two of the rotations are wrong according to my testing so I decided to be a good citizen and upstream the changes.

I have attached a schematic file that demonstrates the problem. It uses MTG stairs. I had to change the file extension from .mts to .zip to upload it to Github.

[ice.zip](https://github.com/Skamiz/world_builder/files/11021531/ice.zip)
